### PR TITLE
Fix: Enabled full screen buttons for studio users

### DIFF
--- a/openedxscorm_v2/scormxblock.py
+++ b/openedxscorm_v2/scormxblock.py
@@ -159,9 +159,9 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             context[
                 "message"
             ] = "Click 'Edit' to modify this module and upload a new SCORM package."
-        return self.student_view(context=context)
+        return self.student_view(context=context, is_author=True);
 
-    def student_view(self, context=None):
+    def student_view(self, context=None, is_author=False):
         self._get_package_file_and_extract()
 
         student_context = {
@@ -171,7 +171,10 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             "scorm_xblock": self,
         }
         student_context.update(context or {})
-        template = self.render_template("static/html/scormxblock.html", student_context)
+        if is_author: 
+            template = self.render_template("static/html/scormstudioxblock.html", student_context)
+        else: 
+            template = self.render_template("static/html/scormxblock.html", student_context)
         frag = Fragment(template)
         frag.add_css(self.resource_string("static/css/scormxblock.css"))
         frag.add_javascript(self.resource_string("static/js/src/scormxblock.js"))

--- a/openedxscorm_v2/scormxblock.py
+++ b/openedxscorm_v2/scormxblock.py
@@ -159,9 +159,9 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             context[
                 "message"
             ] = "Click 'Edit' to modify this module and upload a new SCORM package."
-        return self.student_view(context=context, is_author=True);
+        return self.student_view(context=context, viewer="creator");
 
-    def student_view(self, context=None, is_author=False):
+    def student_view(self, context=None, viewer="learner"):
         self._get_package_file_and_extract()
 
         student_context = {
@@ -171,7 +171,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             "scorm_xblock": self,
         }
         student_context.update(context or {})
-        if is_author: 
+        if viewer == 'creator': 
             template = self.render_template("static/html/scormstudioxblock.html", student_context)
         else: 
             template = self.render_template("static/html/scormxblock.html", student_context)

--- a/openedxscorm_v2/static/css/scormxblock.css
+++ b/openedxscorm_v2/static/css/scormxblock.css
@@ -39,3 +39,29 @@
     z-index: 10000;
     background-color: #ffffff;
 }
+
+/* adjusted styles for studio view */
+.openedxscorm_block.openedxscorm-studio .full-screen-scorm  .scorm_object {
+    top: 55px;
+    height: calc(100% - 65px);
+}
+
+.openedxscorm_block .scorm_button {
+    padding-bottom: 20px;
+}
+
+.openedxscorm_block .full-screen-scorm .scorm_button {
+    padding: 20px;
+}
+
+.openedxscorm_block .full-screen-off {
+    display: none;
+}
+
+.openedxscorm_block .full-screen-scorm .full-screen-off {
+    display: block;
+}
+
+.openedxscorm_block .full-screen-scorm .full-screen-on {
+    display: none;
+}

--- a/openedxscorm_v2/static/html/scormstudioxblock.html
+++ b/openedxscorm_v2/static/html/scormstudioxblock.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+<div class="openedxscorm_block openedxscorm-studio">
+    {% if index_page_url %}
+
+    <div class="js-scorm-block">
+        <div class="scorm_button">
+            <button class="js-button-full-screen full-screen-on">
+                {% trans "Fullscreen" %}
+            </button>
+            <button class="js-button-full-screen full-screen-off">
+                {% trans "Exit fullscreen" %}
+            </button>
+        </div>
+        <iframe class="scorm_object" src="{{ index_page_url }}" width="{% if scorm_xblock.width %}{{ scorm_xblock.width }}{% else %}100%{% endif %}" {% if scorm_xblock.height %}height="{{ scorm_xblock.height }}" {% endif %}></iframe>
+    </div>
+    {% elif message %}
+    <p>{{ message }}</p>
+    {% endif %}
+</div>

--- a/openedxscorm_v2/static/js/src/scormxblock.js
+++ b/openedxscorm_v2/static/js/src/scormxblock.js
@@ -62,6 +62,11 @@ function ScormXBlock(runtime, element, settings) {
     $(element).find(".js-scorm-block").addClass("full-screen-scorm");
     triggerResize();
   }
+  function exitFullscreen() {
+    $(element).find(".js-scorm-block").removeClass("full-screen-scorm");
+    fullscreenOnNextEvent = true;
+    triggerResize();
+  }
   function triggerResize() {
     // This is required to trigger the actual content resize in some packages
     window.dispatchEvent(new Event("resize"));
@@ -204,5 +209,16 @@ function ScormXBlock(runtime, element, settings) {
       CommitData: CommitData,
     };
     enterFullscreen();
+    // added click event listener for fullscreen buttons in studio
+    $(element)
+      .find("button.full-screen-on")
+      .on("click", function () {
+        enterFullscreen();
+      });
+    $(element)
+      .find("button.full-screen-off")
+      .on("click", function () {
+        exitFullscreen();
+      });
   });
 }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(os.path.join(here, "README.rst"), "rt", encoding="utf8") as f:
 
 setup(
     name="openedx-scorm-xblock-v2",
-    version="11.3.9",
+    version="11.3.10",
     description="Scorm XBlock for Open edX",
     long_description=readme,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
**Description**
This PR contains the fix to add enter/exit fullscreen buttons in the SCORM package for studio users. By default, the LXP users will not be able to view the full-screen buttons.
 - [x] version bumped

**JIRA**
TBA

@krishnamadhavan 
