### PR TITLE
feat: send actual grade to edX regardless of student pass/fail status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(os.path.join(here, "README.rst"), "rt", encoding="utf8") as f:
 
 setup(
     name="openedx-scorm-xblock-v2",
-    version="11.3.13",
+    version="11.3.14",
     description="Scorm XBlock for Open edX",
     long_description=readme,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
**Description**

- This PR updates the grading logic to send the actual grade value to the edX side, regardless of whether the student has passed or failed in SCORM activity.

- [x] version bumped

**Screenshots**

![image](https://github.com/user-attachments/assets/f0628d55-a5ef-4d60-95ab-89d7f2122294)
