### PR TITLE
fix: 404 issue for scorm blocks having id such as scorm_v2

### DIFF
--- a/openedxscorm_v2/scormxblock.py
+++ b/openedxscorm_v2/scormxblock.py
@@ -378,6 +378,24 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     def extract_folder_base_path(self):
         """
         Path to the folder where packages will be extracted.
+        Compute hash of the unique block usage_id and use that as our directory name.
+        """
+        # For backwards compatibility, we return the old path if the directory exists
+        if self.storage.exists(self.extract_old_folder_base_path):
+            if 'scorm_v2' not in self.extract_old_folder_base_path:
+                return self.extract_old_folder_base_path
+        sha1 = hashlib.sha1()
+        sha1.update(str(self.scope_ids.usage_id).encode())
+        hashed_usage_id = sha1.hexdigest()
+        return os.path.join(self.scorm_location(), hashed_usage_id)
+
+    @property
+    def extract_old_folder_base_path(self):
+        """
+        Deprecated Path to the folder where packages will be extracted.
+        Deprecated as the block_id was shared by courses when exporting and importing
+        them, thus causing storage conflicts.
+        Only keeping this here for backwards compatibility.
         """
         return os.path.join(self.scorm_location(), self.location.block_id)
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(os.path.join(here, "README.rst"), "rt", encoding="utf8") as f:
 
 setup(
     name="openedx-scorm-xblock-v2",
-    version="11.3.15",
+    version="11.3.16",
     description="Scorm XBlock for Open edX",
     long_description=readme,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
**Description ** 

This PR fixes following issue 

- SCORM package will store things in a folder like `/path/to/storage/scorm/block_id` 
- This `block_id` is supposed to be unique 
- But in some cases in import export or in other cases this block id stays the same or generates as `scorm_v21` or `scorm_v22` etc
- Because of that along with removal of other things in the folder, an issue rises which makes the scorm with such ids like `scorm_v21` as block id give 404, this happens because we are deleting the files from storage
- So if multiple courses have multiple scorms and they share the id of `scorm_v21` or `scorm_v22` etc then only of them can work at a time, and if they share the id via import export then too this issue can occur
- This PR fixes that

**Related PR** 

[- Add to Dev](https://github.com/WHOAcademy/openedx-tutor-config/pull/221)
- Add to UAT 
- Add to Staging

